### PR TITLE
Remove sonar and publish jobs from project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,14 @@ env:
 stages:
   - build
   - unit-test
-  - test-e2e
-  - release-ff
-  - publish
+  # - test-e2e
+  - release-ff 
 
 before_script:
   # Bootstrap the build harness.
   - make
   # Set the image tag differently for PRs.
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
-
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi; 
 
 jobs:
   include:
@@ -61,9 +59,7 @@ jobs:
         # Bootstrap the build harness, pull test image, and run unit tests.  
         # - make component/pull 
         - make component/test/unit
-        - make security/scans
-        - make sonar/go  
-
+        - make security/scans 
     # - stage: test-e2e
     #   name: "Deploy the image to a cluster and run e2e tests"
     #   if: type = pull_request
@@ -71,16 +67,9 @@ jobs:
     #     #Check out a clusterpool, set up oc, deploy, run e2e tests, and return clusterpool cluster
     #     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
     #     - make component/pull 
-    #     - make component/test/e2e
-
+    #     - make component/test/e2e 
     - stage: release-ff
       name: "Push commits to current release branch"
       if: type = push AND branch =~ /^main$/
       script:
-        - make release-ff
-
-    - stage: publish
-      name: "Publish the image to quay with an official version/sha tag and publish entry to integration pipeline stage"
-      if: type = push AND branch =~ /^release-[0-9]+\..*$/
-      script:
-        - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+        - make release-ff 

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -4,4 +4,10 @@
 
 .PHONY: unit-test
 unit-test:
-	go test ./... -v -coverprofile cover.out
+	go test ./... -v -coverprofile cover.out 
+
+.PHONY: lint
+lint:
+	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.38.0
+	# Flag GOGC=25 needed to run garbage collection more often and avoid out of memory issue.
+	GOGC=25 golangci-lint run --timeout=3m


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#10511

### Description of changes
Removes the publish and sonar related items from .travis.yml . These changes are part of prow onboarding. 

Step 1: turn off travis
Step 2: turn on these things in prow
Step 3: completely extricate travis from this project. 

https://github.com/open-cluster-management/cicd-docs/blob/main/prow/ONBOARDING.md#working-with-an-existing-component

