### PR TITLE
disable readiness check

### DIFF
--- a/pkg/handlers/healthProbes.go
+++ b/pkg/handlers/healthProbes.go
@@ -16,7 +16,6 @@ import (
 	"net/http"
 
 	"github.com/golang/glog"
-	db "github.com/open-cluster-management/search-aggregator/pkg/dbconnector"
 )
 
 // LivenessProbe is used to check if this service is alive.
@@ -31,15 +30,15 @@ func ReadinessProbe(w http.ResponseWriter, r *http.Request) {
 
 	// Go straight to the pool's Dial because we don't actually want to play by the pool's
 	// rules here - just want a connection unrelated to all the other ones,
-	conn, err := db.Pool.Dial()
-	if err != nil {
-		// Respond with error.
-		glog.Warning("Unable to reach Redis.")
-		http.Error(w, "Unable to reach Redis.", 503)
-		return
-	}
+	// conn, err := db.Pool.Dial()
+	// if err != nil {
+	// 	// Respond with error.
+	// 	glog.Warning("Unable to reach Redis.")
+	// 	http.Error(w, "Unable to reach Redis.", 503)
+	// 	return
+	// }
 
-	defer conn.Close()
+	// defer conn.Close()
 	// Respond with success
 	fmt.Fprint(w, "OK")
 }

--- a/pkg/handlers/healthProbes_test.go
+++ b/pkg/handlers/healthProbes_test.go
@@ -41,7 +41,7 @@ func TestLivenessProbe(t *testing.T) {
 }
 
 // Test the readiness probe.
-func TestReadinessProbe_unableToConnect(t *testing.T) {
+/*func TestReadinessProbe_unableToConnect(t *testing.T) {
 	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
 	// pass 'nil' as the third parameter.
 	req, err := http.NewRequest("GET", "/readiness", nil)
@@ -65,6 +65,37 @@ func TestReadinessProbe_unableToConnect(t *testing.T) {
 
 	// Check the response body is what we expect.
 	expected := "Unable to reach Redis.\n"
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}*/
+
+// Test the readiness probe.
+func TestReadinessProbe_ableToConnect(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req, err := http.NewRequest("GET", "/readiness", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(ReadinessProbe)
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusServiceUnavailable)
+	}
+
+	// Check the response body is what we expect.
+	expected := "OK"
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#11303

### Description of changes

**Note:** This change isn't ideal, but after trying other options we are choosing to disable the readiness probe so the search component can report a success state when Redisgraph isn't deployed.