### PR TITLE
[release 2.4] update 2.4 to go 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/open-cluster-management/builder:go1.16-linux AS builder
+FROM registry.ci.openshift.org/open-cluster-management/builder:go1.17-linux AS builder
 
 WORKDIR /go/src/github.com/open-cluster-management/search-aggregator
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,46 @@ require (
 	open-cluster-management.io/api v0.0.0-20210916013819-2e58cdb938f9
 )
 
+require (
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/mattn/go-runewidth v0.0.7 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.22.1 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/utils v0.0.0-20210802155522-efc7438f0176 // indirect
+	sigs.k8s.io/controller-runtime v0.6.2 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
 replace (
 	github.com/buger/jsonparser => github.com/buger/jsonparser v1.1.1
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 // Copyright Contributors to the Open Cluster Management project
 module github.com/open-cluster-management/search-aggregator
 
-go 1.16
+go 1.17
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

**Related Issue:**  open-cluster-management/backlog#15570

### Description of changes

